### PR TITLE
[Refactor]: 모임생성 필드 우효~성 검사 리펙토링

### DIFF
--- a/src/app/post-meetup/page.tsx
+++ b/src/app/post-meetup/page.tsx
@@ -34,6 +34,7 @@ const PostMeetupPage = () => {
     } as CreateGroupFormValues,
     validators: {
       onChange: createGroupSchema,
+      onSubmit: createGroupSchema,
     },
     onSubmit: async ({ value }) => {
       const images = [] as PreUploadGroupImageResponse['images'];

--- a/src/components/pages/post-meetup/fields/cap-field/index.tsx
+++ b/src/components/pages/post-meetup/fields/cap-field/index.tsx
@@ -3,15 +3,13 @@
 import { AnyFieldApi } from '@tanstack/react-form';
 
 import { Icon } from '@/components/icon';
-import { Hint, Input, Label } from '@/components/ui';
+import { Input, Label } from '@/components/ui';
 
 interface Props {
   field: AnyFieldApi;
 }
 
 export const MeetupCapField = ({ field }: Props) => {
-  const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-
   return (
     <div className='mt-3 flex w-full flex-col gap-1'>
       <Label htmlFor='post-meetup-cap' required>
@@ -43,8 +41,6 @@ export const MeetupCapField = ({ field }: Props) => {
           field.handleChange(Number(e.target.value));
         }}
       />
-
-      {isInvalid && <Hint className='mt-0.5' message={field.state.meta.errors[0].message} />}
     </div>
   );
 };

--- a/src/components/pages/post-meetup/fields/detail-feild/index.tsx
+++ b/src/components/pages/post-meetup/fields/detail-feild/index.tsx
@@ -18,7 +18,7 @@ export const MeetupDetailField = ({ field }: Props) => {
       </Label>
       <textarea
         id='post-meetup-Detail'
-        className='bg-mono-white focus:border-mint-500 text-text-md-medium h-40 w-full resize-none rounded-2xl border border-gray-300 px-5 py-4 text-gray-800 focus:outline-none'
+        className='bg-mono-white scrollbar-thin focus:border-mint-500 text-text-md-medium h-40 w-full resize-none rounded-2xl border border-gray-300 px-5 py-4 text-gray-800 focus:outline-none'
         maxLength={300}
         placeholder='모임에 대해 설명해주세요'
         required
@@ -27,7 +27,7 @@ export const MeetupDetailField = ({ field }: Props) => {
       />
       <div className='mt-0.5 flex'>
         {isInvalid && <Hint message={field.state.meta.errors[0].message} />}
-        <div className='text-text-sm-medium w-full text-right text-gray-500'>
+        <div className='text-text-sm-medium ml-auto text-right text-gray-500'>
           {field.state.value.length}/300
         </div>
       </div>

--- a/src/components/pages/post-meetup/fields/tags-field/index.tsx
+++ b/src/components/pages/post-meetup/fields/tags-field/index.tsx
@@ -6,7 +6,7 @@ import { AnyFieldApi } from '@tanstack/react-form';
 import clsx from 'clsx';
 
 import { Icon } from '@/components/icon';
-import { Input, Label } from '@/components/ui';
+import { Hint, Input, Label } from '@/components/ui';
 
 interface Props {
   field: AnyFieldApi;
@@ -21,16 +21,18 @@ export const MeetupTagsField = ({ field }: Props) => {
     if (e.nativeEvent.isComposing) return;
 
     const isUniqueTag = !field.state.value.includes(inputValue);
-    const nonEmpty = inputValue.trim();
-    const tagsCount = field.state.value.length;
+    const isValidTag = inputValue.trim() && inputValue.length <= 8;
+    const isBelowMaxLength = field.state.value.length < 10;
 
-    if (isUniqueTag && nonEmpty && tagsCount < 10) {
+    if (isUniqueTag && isValidTag && isBelowMaxLength) {
       field.pushValue(inputValue);
     }
 
     inputRef.current?.focus();
     setInputValue('');
   };
+
+  const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
 
   return (
     <div className='flex w-full flex-col gap-1'>
@@ -74,6 +76,7 @@ export const MeetupTagsField = ({ field }: Props) => {
       </ul>
 
       <p className='text-text-sm-medium px-2 text-gray-500'>최대 10개까지 업로드할 수 있어요.</p>
+      {isInvalid && <Hint className='mt-0.5' message={field.state.meta.errors[0].message} />}
     </div>
   );
 };

--- a/src/lib/schema/group.ts
+++ b/src/lib/schema/group.ts
@@ -3,13 +3,18 @@ import { z } from 'zod';
 export const createGroupSchema = z.object({
   title: z
     .string()
-    .min(2, '제목은 2자 이상 입력해주세요.')
-    .max(50, '제목은 50자 이내 입력해주세요.'),
-  location: z.string().nonempty('모임 장소를 입력해주세요.'),
-  startTime: z.string().nonempty('날짜와 시간을 입력해주세요.'),
-  tags: z.array(z.string()).optional(),
-  description: z.string().nonempty('상세 정보를 입력해주세요.'),
-  maxParticipants: z.number({ error: '' }).min(2, '최대 인원을 입력해주세요.').max(12),
+    .trim()
+    .nonempty('모임 제목을 입력해 주세요.')
+    .max(50, '모임 제목은 50자 이내 입력해 주세요.'),
+  location: z.string().nonempty('모임 장소를 입력해 주세요.'),
+  startTime: z.string().nonempty('모임 날짜와 시간을 입력해 주세요.'),
+  tags: z.array(z.string().nonempty().max(8, '태그는 8자 이내 입력해 주세요.')).max(10).optional(),
+  description: z
+    .string()
+    .trim()
+    .min(1, '모임 상세 정보를 입력해 주세요.')
+    .max(300, '모임 상세 정보는 300자 이내 입력해 주세요.'),
+  maxParticipants: z.number().min(2, '최대 인원을 입력해 주세요.').max(12),
   images: z
     .array(
       z.object({


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->

[삽질]
- onChange 버리고 onBlur 적용
- onBlur만 하니깐 이상해 보여서 onChange 쓰까봄
- tanstack-form이 onBlur + onChange를 동시에 지원안함. (onChange 또는 onBlur 둘중에 발동하는 한가지가 선점을 함.)
- onChange를 다시보니 선녀, 원래 상태로 원복
- 잃어 버린 4시간

[그나마 한거]
- 제목 필드 2자 내외 경고를 빼버림. 이유는 어차피 서버에서도 1자 이상부터 받고 있기도 했고.
2자 내외를 걸어버리면, onChange로 발생하는 경고 메세지가 글자 단 1개만 써도 즉시 튀어나오는 불쾌함이 있음.
그래서 그냥 nonEmpty만 거는걸로 셀프 합의봄 (자기 합리화).
- 상세 필드 300자 제한을 textArea의 max 속성으로 걸어놨다고 귀찮아서 zod 경고 안함. 
하지만 본인같은 악질 유저들은 개발자 도구 키고 max값을 수정할 것을 알기에 zod로 300자 이내 제한함. 
(물론 서버에서 막히겠지만 API 요청 자체를 원천 차단)
- 태그 필드 입력시 배열에 추가되는 형태이기 때문에 zod를 통해 유효성 검사하기가 까다로움.
그래서 Enter로 입력 받는 시점에서 (기존 배열에 중복 태그는 없는지, 길이는 1~8자 인지, 총 개수가 10개를 넘지 않는지)
하드코딩 검증을 통해 우효~~한 태그만 입력받음.

---

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 (PR merge 시 자동으로 이슈가 닫힙니다) -->

Closes #

---

## 🧪 테스트 방법

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요 -->

- [ ] 수동 테스트 검증(로컬 환경)
- [ ] 유닛 테스트 검증
- [ ] 통합 테스트 검증

---

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

---

## 📋 체크리스트

- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)
- [ ] 테스트를 추가/수정했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 명시했습니다

---

## 💬 추가 코멘트

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

---

CodeRabbit Review는 자동으로 실행되지 않습니다.

Review를 실행하려면 comment에 아래와 같이 작성해주세요

```bash
@coderabbitai review
```

---
