### PR TITLE
[Fix] 모임생성 이후 replace path 주소 Group 대문자에서 group 소문자로 수정

### DIFF
--- a/src/app/create-group/[groupId]/page.tsx
+++ b/src/app/create-group/[groupId]/page.tsx
@@ -65,7 +65,7 @@ const EditGroupPage = ({ params }: Props) => {
 
       const res = await EditGroup(value);
 
-      replace(`/Group/${res.id}`);
+      replace(`/group/${res.id}`);
     },
   });
 

--- a/src/app/create-group/page.tsx
+++ b/src/app/create-group/page.tsx
@@ -43,7 +43,7 @@ const CreateGroupPage = () => {
 
       const res = await createGroup(value);
 
-      replace(`/Group/${res.id}`);
+      replace(`/group/${res.id}`);
     },
   });
 


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->

- 모임생성 이후 replace 하는 path 주소 이름을 Group 대문자로 적용해서 redirect 오류가 있었음.
소문자 group 으로 변경하여 정상적으로 페이지 이동하게 해결함.

---

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 (PR merge 시 자동으로 이슈가 닫힙니다) -->

Closes #

---

## 🧪 테스트 방법

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요 -->

- [ ] 수동 테스트 검증(로컬 환경)
- [ ] 유닛 테스트 검증
- [ ] 통합 테스트 검증

---

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

---

## 📋 체크리스트

- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)
- [ ] 테스트를 추가/수정했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 명시했습니다

---

## 💬 추가 코멘트

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

---

CodeRabbit Review는 자동으로 실행되지 않습니다.

Review를 실행하려면 comment에 아래와 같이 작성해주세요

```bash
@coderabbitai review
```

---
