### PR TITLE
[Fix] 모임 삭제 이후 목록 새로 갱신

### DIFF
--- a/src/hooks/use-group/use-group-delete/index.ts
+++ b/src/hooks/use-group/use-group-delete/index.ts
@@ -1,12 +1,18 @@
 import { useMutation } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { API } from '@/api';
+import { groupKeys } from '@/lib/query-key/query-key-group';
 import { GroupIdParams } from '@/types/service/group';
 
 export const useDeleteGroup = (params: GroupIdParams) => {
+  const queryClient = useQueryClient();
+
   const query = useMutation({
     mutationFn: () => API.groupService.deleteGroup(params),
     onSuccess: async () => {
+      queryClient.removeQueries({ queryKey: groupKeys.detail(params.groupId) });
+      queryClient.invalidateQueries({ queryKey: groupKeys.lists() });
       console.log('모임 삭제 성공.');
     },
     onError: () => {


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->

[문제]
- 기존 모임 삭제 이후 목록으로 replace -> 이동 이후 기존 목록이 캐싱되어 방금 삭제한 모임이 그대로 보임 

[해결] 
- 모임 삭제 이후 모임 목록 쿼리 키 invalidate로 refetch 적용

[트러블슈팅]
- 모임 삭제 이후 history back을 통해 방금 삭제했던 모임의 상세 페이지로 이동할 수 있음. (replace 를 적용했다 하더라도 악의 적으로 history를 2~3번 이상 쌓으면 replace 또한 해결책이 될 수 없음).
- history back으로 삭제된 모임 상세 페이지내에서 특별히 할 수 있는 것은 없음 (서버에서 막음 처리)

[트러블슈팅 삽질 과정]
- tanstack-query의 caching이 문제라 생각해봄 그래서 모임 delete 이후 removeQueries를 적용해서 detail 캐싱을 날려버림.
여전히 history back으로 상세 페이지에 접근하면 예전 정보가 그대로 보임.
- 브라우저 자체도 history에 캐싱을 해둔다는 것을 알게됨 그래서 next/navigation의 useRouter.refresh 기능을 사용해 봤지만
잘 못 사용한건지 여전히 history back 캐시를 날리지 못함.

[결론]
- history back 까지 신경 써야하는걸까?
- 나중에 시간나면 다시 돌아와 보겠음.

---

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 (PR merge 시 자동으로 이슈가 닫힙니다) -->

Closes #

---

## 🧪 테스트 방법

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요 -->

- [ ] 수동 테스트 검증(로컬 환경)
- [ ] 유닛 테스트 검증
- [ ] 통합 테스트 검증

---

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

---

## 📋 체크리스트

- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)
- [ ] 테스트를 추가/수정했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 명시했습니다

---

## 💬 추가 코멘트

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

---

CodeRabbit Review는 자동으로 실행되지 않습니다.

Review를 실행하려면 comment에 아래와 같이 작성해주세요

```bash
@coderabbitai review
```

---
