### PR TITLE
[Feat] FREE 모임 참가 이후 토스터 팝업 적용

### DIFF
--- a/src/components/pages/group/group-modal/index.tsx
+++ b/src/components/pages/group/group-modal/index.tsx
@@ -4,7 +4,9 @@ import { useParams, useRouter } from 'next/navigation';
 
 import { GroupModalApprovalContent } from '@/components/pages/group/group-modal/approval-content';
 import { GroupModalCommonContent } from '@/components/pages/group/group-modal/common-content';
+import { Toast } from '@/components/ui';
 import { ModalContent } from '@/components/ui/modal';
+import { useToast } from '@/components/ui/toast/core';
 import { useAttendGroup } from '@/hooks/use-group/use-group-attend';
 import { useDeleteGroup } from '@/hooks/use-group/use-group-delete';
 import { useKickGroupMember } from '@/hooks/use-group/use-group-kick';
@@ -32,6 +34,7 @@ export const GroupModal = (props: Props) => {
 
   const { replace } = useRouter();
   const { groupId } = useParams() as { groupId: string };
+  const { run } = useToast();
 
   const { mutateAsync: attendMutate, isPending: isAttending } = useAttendGroup({ groupId });
   const { mutateAsync: leaveMutate, isPending: isCanceling } = useLeaveGroup({ groupId });
@@ -44,7 +47,14 @@ export const GroupModal = (props: Props) => {
   const isPending = isAttending || isCanceling || isDeleting || isKicking;
 
   const mutateByType = {
-    attend: () => attendMutate(undefined),
+    attend: async () => {
+      await attendMutate(undefined);
+      run(
+        <Toast offset='button' type='success'>
+          모임 신청 완료! Share the fun
+        </Toast>,
+      );
+    },
     approval: (message: AttendGroupPayload) => attendMutate(message),
     pending: () => leaveMutate(),
     leave: () => leaveMutate(),


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->

- 토스터 적용함

[걱정되는거]
- react-query를 잘모르는데 얼핏 알기론 onSuccess 친구는 HTTP 프로토콜 200을 기준으로 성공했다가 아닌
400~500대 에러 코드가 와도 onSuccess가 실행한다고 들었다. (잘못 주워들었을 수도 있음)
- 하지만 지금까지 서버에서 에러 코드가 올때 onError 단에서 "실패" log가 찍히는 것을 보면, 아마 axios 단에서 error 코드가 오면 throw Error를 해줘서 react-query의 onSuccess에 빨려 드러가지 않는 것 같음. (맞나?)

---

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 (PR merge 시 자동으로 이슈가 닫힙니다) -->

Closes #

---

## 🧪 테스트 방법

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요 -->

- [ ] 수동 테스트 검증(로컬 환경)
- [ ] 유닛 테스트 검증
- [ ] 통합 테스트 검증

---

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

---

## 📋 체크리스트

- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)
- [ ] 테스트를 추가/수정했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 명시했습니다

---

## 💬 추가 코멘트

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

---

CodeRabbit Review는 자동으로 실행되지 않습니다.

Review를 실행하려면 comment에 아래와 같이 작성해주세요

```bash
@coderabbitai review
```

---
