### PR TITLE
[Fix]: 모임생성 날짜 필드에서 현재 시간 이상만 받도록 zod 유효성검사 수정

### DIFF
--- a/src/lib/schema/group.ts
+++ b/src/lib/schema/group.ts
@@ -7,7 +7,10 @@ export const createGroupSchema = z.object({
     .nonempty('모임 제목을 입력해 주세요.')
     .max(50, '모임 제목은 50자 이내 입력해 주세요.'),
   location: z.string().nonempty('모임 장소를 입력해 주세요.'),
-  startTime: z.coerce.date().min(new Date(), '모임 시간은 현재시간 이후로 입력해 주세요.'),
+  startTime: z
+    .string()
+    .nonempty('모임 날짜와 시간을 입력해 주세요.')
+    .refine((value) => new Date() < new Date(value), '모임 시간은 현재 이후로 입력해 주세요.'),
   tags: z.array(z.string().nonempty().max(8, '태그는 8자 이내 입력해 주세요.')).max(10).optional(),
   description: z
     .string()


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->

[삽질]
- z.coerce로 date를 받아 min date 를 충족하는지 판단 하려함. 하지만, 기존 form의 startTime 필드는 string 값을 기록하고 있음.
이러한 이유로 string과 date간의 타입 충돌이 발생했고 결론적으로 coerce 계산을 버리고 기존 startTime의 schema 대로 string을 입력받은 후 refined 를 활용해 입력 받은 string을 직접 new Date(value) 로 변환해서 유효한 시간인지 검사함.

[수확]
- Zod 유효성 검사에서 z.coerce new Date 객체를 호출해서 특정 시간을 기준으로 유효성 검사를 할 수 있다는 것을 알게됨. (갸꿀)
  - 꿀인줄 알았으나, z.coerce.date() 를 활용하는 순간 form의 default value 또한 Date의 타입을 가저야함.
  - 만약, place holder 메세지가 없고 처음부터 디폴트 date가 선택 되어있는 일반적인 date picker 였다면 string -> date의 타입 변환 과정을 생략해도 되기 때문에 개꿀이 맞음. 단지 우리 디자인에선 못 써먹음 ㅠ. 

---

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 (PR merge 시 자동으로 이슈가 닫힙니다) -->

Closes #

---

## 🧪 테스트 방법

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요 -->

- [ ] 수동 테스트 검증(로컬 환경)
- [ ] 유닛 테스트 검증
- [ ] 통합 테스트 검증

---

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

---

## 📋 체크리스트

- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)
- [ ] 테스트를 추가/수정했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 명시했습니다

---

## 💬 추가 코멘트

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

---

CodeRabbit Review는 자동으로 실행되지 않습니다.

Review를 실행하려면 comment에 아래와 같이 작성해주세요

```bash
@coderabbitai review
```

---
