### PR TITLE
[Feat] layout header 로그인 버튼 UI 추가 및 랜더링 분기 처리

### DIFF
--- a/src/components/layout/header/cow-bell/index.tsx
+++ b/src/components/layout/header/cow-bell/index.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+
+import { Icon } from '@/components/icon';
+import { cn } from '@/lib/utils';
+import { useNotification } from '@/providers';
+
+export const CowBell = () => {
+  const { unReadCount, receivedNewNotification } = useNotification();
+
+  return (
+    <Link href={'/notification'} className='flex-center relative h-10 w-10'>
+      <Icon
+        id='bell-read'
+        className={cn(
+          'size-10 text-gray-700 transition-colors duration-200',
+          receivedNewNotification && 'animate-ring text-mint-500',
+        )}
+      />
+      {unReadCount > 0 && (
+        <>
+          <span
+            className={cn(
+              'bg-mint-300 absolute top-1 right-1.75 aspect-square size-3.5 rounded-full',
+              receivedNewNotification && 'animate-ping',
+            )}
+          />
+          <span className='bg-mint-500 text-mono-white text-text-2xs-semibold flex-center absolute top-1 right-1.75 aspect-square size-3.5 rounded-full'>
+            {unReadCount}
+          </span>
+        </>
+      )}
+    </Link>
+  );
+};

--- a/src/components/layout/header/header-login/index.tsx
+++ b/src/components/layout/header/header-login/index.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link';
+
+export const HeaderLogin = () => {
+  return (
+    <Link href={'/login'} className='text-text-sm-semibold px-2 py-1 text-gray-500'>
+      로그인
+    </Link>
+  );
+};

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -1,55 +1,22 @@
 'use client';
+
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
 import { Icon } from '@/components/icon';
-import { cn } from '@/lib/utils';
-import { useAuth, useNotification } from '@/providers';
+import { CowBell } from '@/components/layout/header/cow-bell';
+import { HeaderLogin } from '@/components/layout/header/header-login';
+import { useAuth } from '@/providers';
 
 export const Header = () => {
   const { isAuthenticated } = useAuth();
-  const { unReadCount, receivedNewNotification } = useNotification();
-  const router = useRouter();
-
-  const onLogoClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
-    router.push('/');
-  };
 
   return (
     <header className={`sticky top-0 z-100 w-full bg-white`}>
       <nav className='flex-between px-4 py-2'>
-        <Link href={'/'} onClick={onLogoClick}>
+        <Link href={'/'}>
           <Icon id='wego-logo' width={92} height={40} />
         </Link>
-        <div className='flex-center gap-2'>
-          <Link
-            href={'/notification'}
-            prefetch={isAuthenticated}
-            className='flex-center relative h-10 w-10'
-          >
-            <Icon
-              id='bell-read'
-              className={cn(
-                'size-10 text-gray-700 transition-colors duration-200',
-                receivedNewNotification && 'animate-ring text-mint-500',
-              )}
-            />
-            {unReadCount > 0 && (
-              <>
-                <span
-                  className={cn(
-                    'bg-mint-300 absolute top-1 right-1.75 aspect-square size-3.5 rounded-full',
-                    receivedNewNotification && 'animate-ping',
-                  )}
-                />
-                <span className='bg-mint-500 text-mono-white text-text-2xs-semibold flex-center absolute top-1 right-1.75 aspect-square size-3.5 rounded-full'>
-                  {unReadCount}
-                </span>
-              </>
-            )}
-          </Link>
-        </div>
+        <div className='flex-center gap-2'>{isAuthenticated ? <CowBell /> : <HeaderLogin />}</div>
       </nav>
     </header>
   );

--- a/src/providers/provider-auth/index.tsx
+++ b/src/providers/provider-auth/index.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export const AuthProvider = ({ children, hasRefreshToken }: Props) => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(hasRefreshToken);
 
   // 초기값 설정
   // 페이지가 새로고침 될 때 accessToken이 없으면 refresh 시도, state update 실행


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->

[추가사항]
- 헤더 전용 로그인 버튼 UI 추가
- 로그인 UI, 카우벨 알림 UI 컴포넌트 분리
- 로그인 UI, 카우벨 알림 UI 랜더링 분기 처리

[변경사항]
- useAuth 훅의 default 값을 (false) 에서 -> (hasRefreshToken) 으로 변경

---

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 (PR merge 시 자동으로 이슈가 닫힙니다) -->

Closes #

---

## 🧪 테스트 방법

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요 -->

- [ ] 수동 테스트 검증(로컬 환경)
- [ ] 유닛 테스트 검증
- [ ] 통합 테스트 검증

---

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

---

## 📋 체크리스트

- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)
- [ ] 테스트를 추가/수정했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 명시했습니다

---

## 💬 추가 코멘트

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

---

CodeRabbit Review는 자동으로 실행되지 않습니다.

Review를 실행하려면 comment에 아래와 같이 작성해주세요

```bash
@coderabbitai review
```

---
