### PR TITLE
[Fix] 모임상세 useQuery hook을 useSuspense로 변경

### DIFF
--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -18,8 +18,6 @@ const GroupDetailPage = ({ params }: Props) => {
   const { groupId } = use(params);
   const { data } = useGetGroupDetails({ groupId });
 
-  if (!data) return null;
-
   const { chatRoomId, images, status, joinPolicy, myMembership, joinedMembers } = data;
 
   return (

--- a/src/hooks/use-group/use-group-get-details/index.ts
+++ b/src/hooks/use-group/use-group-get-details/index.ts
@@ -1,11 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { API } from '@/api';
 import { groupKeys } from '@/lib/query-key/query-key-group';
 import { GroupIdParams } from '@/types/service/group';
 
 export const useGetGroupDetails = (params: GroupIdParams) => {
-  const query = useQuery({
+  const query = useSuspenseQuery({
     queryKey: groupKeys.detail(params.groupId),
     queryFn: () => API.groupService.getGroupDetails(params),
   });


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->

[변경 사항]
- 기존 useQuery 로 상세 정보 조회에서 -> useSuspenseQuery 적용
- useSuspenseQuery를 적용했기 때문에 if (!data) return null 코드 또한 삭제

[문제점]
- useSuspenseQuery를 사용한다면 Suspense의 fallback을 적용해야 함.
만약 page의 상위 Layout 단에서 suspense를 걸어둘 시엔 client-side-navigation의 "navigation blocking"은 해지 되기 때문에
목록에서 모임 클릭 시 즉시 routing하며 내가 원했던 전통적인 SSR (HTML 베이킹) 방식으로 동작하지 않음.

[해결?]
- 그래서 그냥 Suspense 적용 없이 useSuspenseQuery로 책임 없는 쾌락?을 즐김.
- useSuspenseQuery의 loading "latency"로 인한 문제가 걱정이 되더라도 상위 SSR Layout 단계에서 fetchQuery로 data를 받지 못한다면 페이지 자체가 생성되지 않고 error.tsx (errorBoundery)에 잡힘. 이러한 점을 고려했을때 Layout의 children은 항상 데이터가  보장된 상태로 랜더링 할 것이고 결과적으로 children의 useSuspenseQuery는 Promise를 throw할 기회조차 없이 SSR에서 fetch한 쿼리키를 기반으로 즉시 렌더링 하기때문에 Suspense fallback을 적용하지 않고 useSuspenseQuery를 안?전?하게 사용할 수 있음 (제미나이 + 뇌피셜 + 자기합리화).



---

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 (PR merge 시 자동으로 이슈가 닫힙니다) -->

Closes #

---

## 🧪 테스트 방법

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요 -->

- [ ] 수동 테스트 검증(로컬 환경)
- [ ] 유닛 테스트 검증
- [ ] 통합 테스트 검증

---

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

---

## 📋 체크리스트

- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)
- [ ] 테스트를 추가/수정했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 명시했습니다

---

## 💬 추가 코멘트

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

---

CodeRabbit Review는 자동으로 실행되지 않습니다.

Review를 실행하려면 comment에 아래와 같이 작성해주세요

```bash
@coderabbitai review
```

---
