### PR TITLE
[Perf] LCP 개선을 위한 Font/Icon/CardTag 컴포넌트 렌더링 최적화 (2.3s → 1.0s)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,20 +3,6 @@ import '@/styles/globals.css';
 import type { Preview } from '@storybook/nextjs';
 
 import { Providers } from '../src/app/providers';
-import { pretendard } from '../src/lib/fonts';
-
-(() => {
-  console.log('body className added');
-  const addFontClass = () => {
-    document.body.classList.add(pretendard.className);
-  };
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', addFontClass, { once: true });
-  } else {
-    addFontClass();
-  }
-})();
 
 const preview: Preview = {
   parameters: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import { Suspense } from 'react';
 import { LayoutWrapper } from '@/components/layout';
 import { initMocks } from '@/mock';
 
-import { pretendard } from '../lib/fonts';
 import { Providers } from './providers';
 
 export const metadata: Metadata = {
@@ -29,7 +28,7 @@ export default async function RootLayout({
 
   return (
     <html lang='ko'>
-      <body className={`${pretendard.className} ${pretendard.variable} antialiased`}>
+      <body className='antialiased'>
         <Suspense fallback={null}>
           <Providers hasRefreshToken={hasRefreshToken}>
             <div id='root'>

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -1,53 +1,52 @@
-// This file is auto-generated. Do not edit manually.
 import { type ComponentProps } from 'react';
 
-import type { IconMetadata } from 'flexisvg';
+import { iconComponentMap } from './registry';
 
-export type DynamicIconId =
-  | 'arrow-down'
-  | 'arrow-up'
-  | 'bell-read'
-  | 'calendar-1'
-  | 'calendar-2'
-  | 'check'
-  | 'chevron-left-1'
-  | 'chevron-left-2'
-  | 'chevron-right-1'
-  | 'clock'
-  | 'edit-bar'
-  | 'edit'
-  | 'heart'
-  | 'home'
-  | 'kebab'
-  | 'map-pin-1'
-  | 'map-pin-2'
-  | 'message'
-  | 'plus'
-  | 'search'
-  | 'send'
-  | 'small-x-1'
-  | 'small-x-2'
-  | 'symbol'
-  | 'tag'
-  | 'user-1'
-  | 'user-2'
-  | 'users-1'
-  | 'users-2'
-  | 'x-1'
-  | 'x-2';
-export type ResizableIconId =
-  | 'bell-unread'
-  | 'congratulate'
-  | 'empty'
-  | 'google-login'
-  | 'kick'
-  | 'not-found'
-  | 'plus-circle'
-  | 'visibility-false'
-  | 'visibility-true'
-  | 'wego-logo';
+export const iconMetadataMap = [
+  { id: 'arrow-down', variant: 'dynamic' },
+  { id: 'arrow-up', variant: 'dynamic' },
+  { id: 'bell-read', variant: 'dynamic' },
+  { id: 'calendar-1', variant: 'dynamic' },
+  { id: 'calendar-2', variant: 'dynamic' },
+  { id: 'check', variant: 'dynamic' },
+  { id: 'chevron-left-1', variant: 'dynamic' },
+  { id: 'chevron-left-2', variant: 'dynamic' },
+  { id: 'chevron-right-1', variant: 'dynamic' },
+  { id: 'clock', variant: 'dynamic' },
+  { id: 'edit-bar', variant: 'dynamic' },
+  { id: 'edit', variant: 'dynamic' },
+  { id: 'heart', variant: 'dynamic' },
+  { id: 'home', variant: 'dynamic' },
+  { id: 'kebab', variant: 'dynamic' },
+  { id: 'map-pin-1', variant: 'dynamic' },
+  { id: 'map-pin-2', variant: 'dynamic' },
+  { id: 'message', variant: 'dynamic' },
+  { id: 'plus', variant: 'dynamic' },
+  { id: 'search', variant: 'dynamic' },
+  { id: 'send', variant: 'dynamic' },
+  { id: 'small-x-1', variant: 'dynamic' },
+  { id: 'small-x-2', variant: 'dynamic' },
+  { id: 'symbol', variant: 'dynamic' },
+  { id: 'tag', variant: 'dynamic' },
+  { id: 'user-1', variant: 'dynamic' },
+  { id: 'user-2', variant: 'dynamic' },
+  { id: 'users-1', variant: 'dynamic' },
+  { id: 'users-2', variant: 'dynamic' },
+  { id: 'x-1', variant: 'dynamic' },
+  { id: 'x-2', variant: 'dynamic' },
+  { id: 'bell-unread', variant: 'resizable' },
+  { id: 'congratulate', variant: 'resizable' },
+  { id: 'empty', variant: 'resizable' },
+  { id: 'google-login', variant: 'resizable' },
+  { id: 'kick', variant: 'resizable' },
+  { id: 'not-found', variant: 'resizable' },
+  { id: 'plus-circle', variant: 'resizable' },
+  { id: 'visibility-false', variant: 'resizable' },
+  { id: 'visibility-true', variant: 'resizable' },
+  { id: 'wego-logo', variant: 'resizable' },
+] as const;
 
-export type IconId = DynamicIconId | ResizableIconId;
+export type IconId = (typeof iconMetadataMap)[number]['id'];
 
 type IconProps = ComponentProps<'svg'> & {
   id: IconId;
@@ -55,176 +54,6 @@ type IconProps = ComponentProps<'svg'> & {
 };
 
 export const Icon = ({ id, size = 24, ...props }: IconProps) => {
-  return (
-    <svg width={size} height={size} {...props}>
-      <use href={`/icons/sprite.svg#${id}`} />
-    </svg>
-  );
+  const IconComponent = iconComponentMap[id];
+  return <IconComponent width={size} height={size} {...props} />;
 };
-
-export const iconMetadataMap: IconMetadata[] = [
-  {
-    id: 'arrow-down',
-    variant: 'dynamic',
-  },
-  {
-    id: 'arrow-up',
-    variant: 'dynamic',
-  },
-  {
-    id: 'bell-read',
-    variant: 'dynamic',
-  },
-  {
-    id: 'calendar-1',
-    variant: 'dynamic',
-  },
-  {
-    id: 'calendar-2',
-    variant: 'dynamic',
-  },
-  {
-    id: 'check',
-    variant: 'dynamic',
-  },
-  {
-    id: 'chevron-left-1',
-    variant: 'dynamic',
-  },
-  {
-    id: 'chevron-left-2',
-    variant: 'dynamic',
-  },
-  {
-    id: 'chevron-right-1',
-    variant: 'dynamic',
-  },
-  {
-    id: 'clock',
-    variant: 'dynamic',
-  },
-  {
-    id: 'edit-bar',
-    variant: 'dynamic',
-  },
-  {
-    id: 'edit',
-    variant: 'dynamic',
-  },
-  {
-    id: 'heart',
-    variant: 'dynamic',
-  },
-  {
-    id: 'home',
-    variant: 'dynamic',
-  },
-  {
-    id: 'kebab',
-    variant: 'dynamic',
-  },
-  {
-    id: 'map-pin-1',
-    variant: 'dynamic',
-  },
-  {
-    id: 'map-pin-2',
-    variant: 'dynamic',
-  },
-  {
-    id: 'message',
-    variant: 'dynamic',
-  },
-  {
-    id: 'plus',
-    variant: 'dynamic',
-  },
-  {
-    id: 'search',
-    variant: 'dynamic',
-  },
-  {
-    id: 'send',
-    variant: 'dynamic',
-  },
-  {
-    id: 'small-x-1',
-    variant: 'dynamic',
-  },
-  {
-    id: 'small-x-2',
-    variant: 'dynamic',
-  },
-  {
-    id: 'symbol',
-    variant: 'dynamic',
-  },
-  {
-    id: 'tag',
-    variant: 'dynamic',
-  },
-  {
-    id: 'user-1',
-    variant: 'dynamic',
-  },
-  {
-    id: 'user-2',
-    variant: 'dynamic',
-  },
-  {
-    id: 'users-1',
-    variant: 'dynamic',
-  },
-  {
-    id: 'users-2',
-    variant: 'dynamic',
-  },
-  {
-    id: 'x-1',
-    variant: 'dynamic',
-  },
-  {
-    id: 'x-2',
-    variant: 'dynamic',
-  },
-  {
-    id: 'bell-unread',
-    variant: 'resizable',
-  },
-  {
-    id: 'congratulate',
-    variant: 'resizable',
-  },
-  {
-    id: 'empty',
-    variant: 'resizable',
-  },
-  {
-    id: 'google-login',
-    variant: 'resizable',
-  },
-  {
-    id: 'kick',
-    variant: 'resizable',
-  },
-  {
-    id: 'not-found',
-    variant: 'resizable',
-  },
-  {
-    id: 'plus-circle',
-    variant: 'resizable',
-  },
-  {
-    id: 'visibility-false',
-    variant: 'resizable',
-  },
-  {
-    id: 'visibility-true',
-    variant: 'resizable',
-  },
-  {
-    id: 'wego-logo',
-    variant: 'resizable',
-  },
-];

--- a/src/components/icon/registry/index.ts
+++ b/src/components/icon/registry/index.ts
@@ -1,0 +1,89 @@
+import { type FC, type SVGProps } from 'react';
+
+import IconArrowDown from '../../../../public/icons/dynamic/icon-arrow-down.svg';
+import IconArrowUp from '../../../../public/icons/dynamic/icon-arrow-up.svg';
+import IconBellRead from '../../../../public/icons/dynamic/icon-bell-read.svg';
+import IconCalendar1 from '../../../../public/icons/dynamic/icon-calendar-1.svg';
+import IconCalendar2 from '../../../../public/icons/dynamic/icon-calendar-2.svg';
+import IconCheck from '../../../../public/icons/dynamic/icon-check.svg';
+import IconChevronLeft1 from '../../../../public/icons/dynamic/icon-chevron-left-1.svg';
+import IconChevronLeft2 from '../../../../public/icons/dynamic/icon-chevron-left-2.svg';
+import IconChevronRight1 from '../../../../public/icons/dynamic/icon-chevron-right-1.svg';
+import IconClock from '../../../../public/icons/dynamic/icon-clock.svg';
+import IconEdit from '../../../../public/icons/dynamic/icon-edit.svg';
+import IconEditBar from '../../../../public/icons/dynamic/icon-edit-bar.svg';
+import IconHeart from '../../../../public/icons/dynamic/icon-heart.svg';
+import IconHome from '../../../../public/icons/dynamic/icon-home.svg';
+import IconKebab from '../../../../public/icons/dynamic/icon-kebab.svg';
+import IconMapPin1 from '../../../../public/icons/dynamic/icon-map-pin-1.svg';
+import IconMapPin2 from '../../../../public/icons/dynamic/icon-map-pin-2.svg';
+import IconMessage from '../../../../public/icons/dynamic/icon-message.svg';
+import IconPlus from '../../../../public/icons/dynamic/icon-plus.svg';
+import IconSearch from '../../../../public/icons/dynamic/icon-search.svg';
+import IconSend from '../../../../public/icons/dynamic/icon-send.svg';
+import IconSmallX1 from '../../../../public/icons/dynamic/icon-small-x-1.svg';
+import IconSmallX2 from '../../../../public/icons/dynamic/icon-small-x-2.svg';
+import IconSymbol from '../../../../public/icons/dynamic/icon-symbol.svg';
+import IconTag from '../../../../public/icons/dynamic/icon-tag.svg';
+import IconUser1 from '../../../../public/icons/dynamic/icon-user-1.svg';
+import IconUser2 from '../../../../public/icons/dynamic/icon-user-2.svg';
+import IconUsers1 from '../../../../public/icons/dynamic/icon-users-1.svg';
+import IconUsers2 from '../../../../public/icons/dynamic/icon-users-2.svg';
+import IconX1 from '../../../../public/icons/dynamic/icon-x-1.svg';
+import IconX2 from '../../../../public/icons/dynamic/icon-x-2.svg';
+import IconBellUnread from '../../../../public/icons/resizable/icon-bell-unread.svg';
+import IconCongratulate from '../../../../public/icons/resizable/icon-congratulate.svg';
+import IconEmpty from '../../../../public/icons/resizable/icon-empty.svg';
+import IconGoogleLogin from '../../../../public/icons/resizable/icon-google-login.svg';
+import IconKick from '../../../../public/icons/resizable/icon-kick.svg';
+import IconNotFound from '../../../../public/icons/resizable/icon-not-found.svg';
+import IconPlusCircle from '../../../../public/icons/resizable/icon-plus-circle.svg';
+import IconVisibilityFalse from '../../../../public/icons/resizable/icon-visibility-false.svg';
+import IconVisibilityTrue from '../../../../public/icons/resizable/icon-visibility-true.svg';
+import IconWegoLogo from '../../../../public/icons/resizable/icon-wego-logo.svg';
+
+type SvgComponent = FC<SVGProps<SVGSVGElement>>;
+
+export const iconComponentMap: Record<string, SvgComponent> = {
+  'arrow-down': IconArrowDown,
+  'arrow-up': IconArrowUp,
+  'bell-read': IconBellRead,
+  'calendar-1': IconCalendar1,
+  'calendar-2': IconCalendar2,
+  check: IconCheck,
+  'chevron-left-1': IconChevronLeft1,
+  'chevron-left-2': IconChevronLeft2,
+  'chevron-right-1': IconChevronRight1,
+  clock: IconClock,
+  'edit-bar': IconEditBar,
+  edit: IconEdit,
+  heart: IconHeart,
+  home: IconHome,
+  kebab: IconKebab,
+  'map-pin-1': IconMapPin1,
+  'map-pin-2': IconMapPin2,
+  message: IconMessage,
+  plus: IconPlus,
+  search: IconSearch,
+  send: IconSend,
+  'small-x-1': IconSmallX1,
+  'small-x-2': IconSmallX2,
+  symbol: IconSymbol,
+  tag: IconTag,
+  'user-1': IconUser1,
+  'user-2': IconUser2,
+  'users-1': IconUsers1,
+  'users-2': IconUsers2,
+  'x-1': IconX1,
+  'x-2': IconX2,
+  'bell-unread': IconBellUnread,
+  congratulate: IconCongratulate,
+  empty: IconEmpty,
+  'google-login': IconGoogleLogin,
+  kick: IconKick,
+  'not-found': IconNotFound,
+  'plus-circle': IconPlusCircle,
+  'visibility-false': IconVisibilityFalse,
+  'visibility-true': IconVisibilityTrue,
+  'wego-logo': IconWegoLogo,
+};

--- a/src/components/shared/card/card-tags/index.test.tsx
+++ b/src/components/shared/card/card-tags/index.test.tsx
@@ -2,13 +2,6 @@ import { render, screen } from '@testing-library/react';
 
 import { type CardTag, CardTags, getLastVisibleIndex } from '.';
 
-// ResizeObserver 목
-global.ResizeObserver = class ResizeObserver {
-  observe = jest.fn();
-  disconnect = jest.fn();
-  unobserve = jest.fn();
-} as unknown as typeof global.ResizeObserver;
-
 describe('getLastVisibleIndex', () => {
   it('태그들이 카드 너비를 넘어가지 않으면 모든 태그를 표시한다', () => {
     const maxWidth = 300;

--- a/src/components/shared/card/card-tags/index.tsx
+++ b/src/components/shared/card/card-tags/index.tsx
@@ -1,8 +1,3 @@
-'use client';
-
-/* eslint-disable react-hooks/set-state-in-effect */
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
-
 export type CardTag = {
   id: string | number;
   label: string;
@@ -11,14 +6,6 @@ export type CardTag = {
 type CardTagsProps = {
   tags: CardTag[];
 };
-
-const TAG_GAP = 4;
-
-const BASE_TAG_CLASSES =
-  'bg-mint-100 text-text-2xs-medium text-mint-700 inline-flex shrink-0 items-center rounded-full px-2 py-0.5';
-
-const HIDDEN_TAG_CLASSES = `${BASE_TAG_CLASSES} invisible absolute`;
-
 export const getLastVisibleIndex = (
   maxWidth: number,
   tagWidths: number[],
@@ -44,71 +31,16 @@ export const getLastVisibleIndex = (
 };
 
 export const CardTags = ({ tags }: CardTagsProps) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const tagRefs = useRef<(HTMLSpanElement | null)[]>([]);
-
-  const [lastVisibleIndex, setLastVisibleIndex] = useState<number | null>(null);
-
-  const updateVisibleTags = useCallback(() => {
-    const container = containerRef.current;
-
-    if (!container || tags.length === 0) {
-      setLastVisibleIndex(null);
-      return;
-    }
-
-    const maxWidth = container.offsetWidth;
-    const tagWidths: number[] = [];
-
-    for (let index = 0; index < tags.length; index++) {
-      const tagElement = tagRefs.current[index];
-      if (!tagElement) {
-        tagWidths.push(0);
-        continue;
-      }
-
-      tagWidths.push(tagElement.offsetWidth);
-    }
-
-    const nextLastVisibleIndex = getLastVisibleIndex(maxWidth, tagWidths, TAG_GAP);
-    setLastVisibleIndex(nextLastVisibleIndex);
-  }, [tags]);
-
-  useLayoutEffect(() => {
-    updateVisibleTags();
-
-    const container = containerRef.current;
-    if (!container) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      updateVisibleTags();
-    });
-
-    resizeObserver.observe(container);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, [updateVisibleTags]);
-
   return (
-    <div ref={containerRef} className='mt-1 flex min-h-5 gap-1'>
-      {tags?.map((tag, index) => {
-        const isVisible = lastVisibleIndex !== null && index <= lastVisibleIndex;
-
-        return (
-          <span
-            key={tag.id}
-            ref={(element) => {
-              tagRefs.current[index] = element;
-            }}
-            className={isVisible ? BASE_TAG_CLASSES : HIDDEN_TAG_CLASSES}
-          >
-            {tag.label}
-          </span>
-        );
-      })}
+    <div className='mt-1 flex max-h-4.5 flex-wrap gap-1 gap-y-0 overflow-hidden'>
+      {tags?.map((tag) => (
+        <span
+          key={tag.id}
+          className='bg-mint-100 text-text-2xs-medium text-mint-700 inline-flex shrink-0 items-center rounded-full px-2 py-0.5'
+        >
+          {tag.label}
+        </span>
+      ))}
     </div>
   );
 };

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,7 +1,0 @@
-import localFont from 'next/font/local';
-
-export const pretendard = localFont({
-  src: [{ path: '../assets/fonts/PretendardVariable.woff2', weight: '45 920' }],
-  variable: '--font-pretendard',
-  display: 'swap',
-});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,4 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 @import 'tailwindcss';
 @import '../styles/base.css';
 @import '../styles/colors.css';
@@ -24,6 +25,13 @@
 }
 
 body {
+  font-family:
+    'Pretendard Variable',
+    Pretendard,
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    sans-serif;
   background: var(--background);
   color: var(--foreground);
 }


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->
# 화면 렌더링 지연 문제 개선 변경사항

> **브랜치**: `chiyoung-fix/card-tag`
> **커밋 범위**: `e2c4832` ~ `919f2df` (3개 커밋)
> **변경 파일**: 7개 (154 additions, 311 deletions)

---

### 커밋 히스토리

| 커밋      | 메시지                                                                                            |
| --------- | ------------------------------------------------------------------------------------------------- |
| `e2c4832` | fix: pretendard font CDN Dynamic Subset 방식으로 전환                                             |
| `dcff104` | fix: card-tag가 useLayoutEffect에 의해 display갯수가 정해지던 방식에서 css overflow 방식으로 전환 |
| `919f2df` | fix: svg sprite 방식에서 SVGR 방식으로 변경                                                       |

---

### 1. Pretendard 폰트 CDN Dynamic Subset으로 전환

#### 문제 원인

`next/font/local`로 Variable 폰트 전체(~2MB)를 로드하고 있어, 폰트 다운로드가 완료될 때까지 텍스트가 흔들리는 현상(FOUT)이 발생했음. 이로 인해 Lighthouse 측정 시 LCP가 Mobile 기준 13.82초, Desktop 기준 2.4초까지 늘어남.

---

#### 수정 1. `src/lib/fonts.ts` 삭제

```typescript
// Before - next/font/local로 Variable 폰트 전체 로드
import localFont from 'next/font/local';

export const pretendard = localFont({
  src: [{ path: '../assets/fonts/PretendardVariable.woff2', weight: '45 920' }],
  variable: '--font-pretendard',
  display: 'swap',
});
```

---

#### 수정 2. `src/app/layout.tsx` - pretendard className 제거

```tsx
// Before
<body className={`${pretendard.className} ${pretendard.variable} antialiased`}>

// After
<body className='antialiased'>
```

---

#### 수정 3. `src/styles/globals.css` - CDN Dynamic Subset import 추가

```css
/* Before - 별도 폰트 import 없음 */
@import 'tailwindcss';

/* After - CDN Dynamic Subset 방식으로 전환 */
@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
@import 'tailwindcss';

body {
  font-family:
    'Pretendard Variable',
    Pretendard,
    -apple-system,
    BlinkMacSystemFont,
    system-ui,
    sans-serif;
}
```

> Dynamic Subset은 페이지에서 실제로 사용되는 글자만 포함된 서브셋 파일을 동적으로 조합하여 로드하므로, Variable 폰트 전체(~2MB)를 받는 대신 필요한 글자만 요청하여 약 263KB로 87% 감소.

---

### 2. card-tag CSS overflow 방식으로 전환

#### 문제 원인

`useLayoutEffect` + `ResizeObserver`로 컨테이너 너비를 측정하여 보이는 태그 수를 JS로 계산하는 방식이었음. SSR 시점에는 DOM이 없으므로 클라이언트에서 hydration 이후에야 태그 표시 여부가 결정되어 렌더링 지연 현상이 발생했음.

```typescript
// Before - 'use client' + useLayoutEffect 기반 JS 너비 계산
'use client';

useLayoutEffect(() => {
  updateVisibleTags(); // DOM 측정 후 setState → 리렌더링 발생
  const resizeObserver = new ResizeObserver(() => updateVisibleTags());
  resizeObserver.observe(container);
  return () => resizeObserver.disconnect();
}, [updateVisibleTags]);

return (
  <div ref={containerRef} className='mt-1 flex min-h-5 gap-1'>
    {tags?.map((tag, index) => {
      const isVisible = lastVisibleIndex !== null && index <= lastVisibleIndex;
      return (
        <span className={isVisible ? BASE_TAG_CLASSES : HIDDEN_TAG_CLASSES}>
          {tag.label}
        </span>
      );
    })}
  </div>
);
```

```typescript
// After - CSS overflow: hidden으로 SSR 시점부터 처리
return (
  <div className='mt-1 flex max-h-4.5 flex-wrap gap-1 gap-y-0 overflow-hidden'>
    {tags?.map((tag) => (
      <span className='bg-mint-100 text-text-2xs-medium text-mint-700 inline-flex shrink-0 items-center rounded-full px-2 py-0.5'>
        {tag.label}
      </span>
    ))}
  </div>
);
```

> `'use client'` 제거로 서버 컴포넌트로 전환. SSR 시점부터 모든 마크업이 HTML에 포함되며, CSS `overflow: hidden`으로 넘치는 태그를 잘라냄. JS로 레이아웃을 계산하던 방식에서 브라우저의 CSS 렌더링에 위임하는 방식으로 변경하여 클라이언트 렌더링 지연이 사라짐.

---

### 3. 아이콘 SVG sprite → SVGR 방식으로 전환

#### 문제 원인

`flexisvg` 기반 SVG sprite 방식은 `<use>` 태그를 사용하여 아이콘을 렌더링함. `<use>` 태그는 브라우저의 SVG 렌더링 엔진이 sprite 파일을 fetch한 이후에야 아이콘이 그려지는 방식으로, SSR 시점 HTML에 아이콘 마크업이 포함되지 않음. 이로 인해 초기 로드 시 아이콘 및 버튼이 제대로 보이지 않고 깜빡이는 현상이 발생했음.

```typescript
// Before - flexisvg SVG sprite 방식 (런타임 HTTP 요청 발생)
import type { IconMetadata } from 'flexisvg';

export type DynamicIconId = 'arrow-down' | 'arrow-up' | ...;
export type ResizableIconId = 'bell-unread' | 'congratulate' | ...;
```

```typescript
// After - SVGR 방식 (SVG를 React 컴포넌트로 import)
import { iconComponentMap } from './registry';

// registry/index.ts에서 각 SVG를 직접 import

// Breaking Changes를 만들지 않기 위해 기존 Icon 사용 구조 유지하며 내부 구조만 변경함

import IconArrowDown from '../../../../public/icons/dynamic/icon-arrow-down.svg';
// ...
export const iconComponentMap = { 'arrow-down': IconArrowDown, ... };
```


> SVGR로 전환하면 각 SVG가 빌드 타임에 JS 번들에 인라인으로 포함됨. 런타임 HTTP 요청이 사라지고, JS 번들은 브라우저에 캐시되므로 재방문 시 추가 네트워크 비용 없이 즉시 렌더링됨. SSR 시점 HTML에도 SVG 마크업이 직접 포함되어 아이콘 로딩 지연이 해소됨.

---

### 개선 결과

| 지표                           | 개선 전  | 개선 후           |
| ------------------------------ | -------- | ----------------- |
| LCP (Desktop)                  | 2.3s     | 1.0s              |
| Lighthouse 성능 점수 (Desktop) | 88       | 99                |
| 폰트 파일 크기                 | ~2,058KB | ~263KB (87% 감소) |

---

### 변경된 파일 목록

| 파일                                                  | 변경 유형                             |
| ----------------------------------------------------- | ------------------------------------- |
| `src/lib/fonts.ts`                                    | **삭제** (next/font/local 제거)       |
| `src/app/layout.tsx`                                  | 수정 (pretendard className 제거)      |
| `src/styles/globals.css`                              | 수정 (CDN Dynamic Subset import 추가) |
| `src/components/shared/card/card-tags/index.tsx`      | 수정 (useLayoutEffect → CSS overflow) |
| `src/components/shared/card/card-tags/index.test.tsx` | 수정 (불필요 테스트 제거)             |
| `src/components/icon/index.tsx`                       | 수정 (flexisvg → SVGR 방식)           |
| `src/components/icon/registry/index.ts`               | **추가** (SVG 컴포넌트 레지스트리)    |

---

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 (PR merge 시 자동으로 이슈가 닫힙니다) -->

Closes #

---

## 🧪 테스트 방법

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요 -->

- [ ] 수동 테스트 검증(로컬 환경)
- [ ] 유닛 테스트 검증
- [ ] 통합 테스트 검증

---

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

전/후 비교 영상(뚜렷한 차이 확인을 위해 CPU x4 감속, Slow 4G 적용

- 변경 전

https://github.com/user-attachments/assets/2da72662-4d48-4acc-9b6d-0e9fdd53fd7c

- 변경 후

https://github.com/user-attachments/assets/62c15cc1-104d-4fa6-bf31-044a3422b8e5

---


## 📋 체크리스트

- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)
- [ ] 테스트를 추가/수정했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 명시했습니다

---

## 💬 추가 코멘트

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

---

CodeRabbit Review는 자동으로 실행되지 않습니다.

Review를 실행하려면 comment에 아래와 같이 작성해주세요

```bash
@coderabbitai review
```

---
